### PR TITLE
Adding variable labels to graph axes and legend when available

### DIFF
--- a/binscatter.ado
+++ b/binscatter.ado
@@ -656,8 +656,26 @@ program define binscatter, eclass sortpreserve
 	
 	* Prepare y-axis title
 	if (`ynum'==1) local ytitle : var label `y_vars'
-	else if (`ynum'==2) local ytitle : subinstr local y_vars " " " and "
-	else local ytitle : subinstr local y_vars " " "; ", all
+	else if (`ynum'==2) {
+		local firstloop "yes"
+		foreach y_var of varlist `y_vars' {
+			local y_varlabel : var label `y_var'
+			if ("`y_varlabel'" == "") local y_varlabel `y_var'
+			if ("`firstloop'" == "yes") local ytitle `y_varlabel'
+			else local ytitle `ytitle' and `y_varlabel'
+			local firstloop "no"
+		}
+	}
+	else {
+		local firstloop "yes"
+		foreach y_var of varlist `y_vars' {
+			local y_varlabel : var label `y_var'
+			if ("`y_varlabel'" == "") local y_varlabel `y_var'
+			if ("`firstloop'" == "yes") local ytitle `y_varlabel'
+			else local ytitle `ytitle', `y_varlabel'
+			local firstloop "no"
+		}
+	}
 	
 	* Prepare x-axis title
 	local xtitle : var label `x_var'


### PR DESCRIPTION
These changes make binscatter use the variable label, instead of the variable name, to label the axes and the legend entries. If the variable label is empty, it uses the variable name instead. This works with "by" and with multiple y-variables. 

I've tested it briefly using the examples given in the help file for binscatter, but I haven't had a chance to exhaustively test it yet. In particular, I don't know what happens when you add special characters (like quotes) to a variable label and then try this command.
