### PR TITLE
Faster regs

### DIFF
--- a/binscatter.ado
+++ b/binscatter.ado
@@ -179,7 +179,7 @@ program define binscatter, eclass sortpreserve
 			local absorb "absorb(`absorb')"
 		}
 		else {
-			local regtype "_regres"
+			local regtype "_regress"
 		}
 	
 		* Generate residuals

--- a/binscatter.ado
+++ b/binscatter.ado
@@ -175,11 +175,11 @@ program define binscatter, eclass sortpreserve
 	
 		* Parse absorb to define the type of regression to be used
 		if `"`absorb'"'!="" {
-			local regtype "areg"
+			local regtype "_regress"
 			local absorb "absorb(`absorb')"
 		}
 		else {
-			local regtype "reg"
+			local regtype "_regres"
 		}
 	
 		* Generate residuals
@@ -277,8 +277,8 @@ program define binscatter, eclass sortpreserve
 					}
 					
 					* perform regression
-					if ("`reg_verbosity'"=="quietly") capture reg `depvar' `x_r2' `x_r' `wt' if `conds'
-					else capture noisily reg `depvar' `x_r2' `x_r' `wt' if `conds'
+					if ("`reg_verbosity'"=="quietly") capture _regress `depvar' `x_r2' `x_r' `wt' if `conds'
+					else capture noisily _regress `depvar' `x_r2' `x_r' `wt' if `conds'
 					
 					* store results
 					if (_rc==0) matrix e_b_temp=e(b)


### PR DESCRIPTION
Simply the use _regress for both reg and areg, speeds things up, esp. the latter (often 3x).

I am not aware of use cases where this breaks anything. E.g the -areg- wrapper does an extra round of _regress without the FEs to report an F-test on them, but no preparation or reporting is broken otherwise.